### PR TITLE
Layout fixes

### DIFF
--- a/src/components/MobileControls.jsx
+++ b/src/components/MobileControls.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { IoArrowForwardOutline, IoArrowBackOutline, IoArrowDownOutline, IoRefreshOutline } from 'react-icons/io5';
-import { StyledDirButton,StyledRotateCe,StyleMCStartStop, StyledControlWrapper, StyledMobileControls, StyledRotateButton } from './styles/StyledMobileControls'
+import { StyledDirButton, StyleMCStartStop, StyledControlWrapper, StyledMobileControls, StyledRotateButton } from './styles/StyledMobileControls'
 
 
 const MobileControls = ({ movePlayer, dropPlayer, setDropTime, level, playerRotate, stage, children }) => {
@@ -28,12 +28,9 @@ const MobileControls = ({ movePlayer, dropPlayer, setDropTime, level, playerRota
                 </StyledDirButton>			
 			
 				{/* rotate */}
-				<StyledRotateCe>
-                    <StyledRotateButton onClick={() => playerRotate(stage, 1)}>
-                        <IoRefreshOutline />
-                    </StyledRotateButton>
-                </StyledRotateCe>
-               
+                <StyledRotateButton onClick={() => playerRotate(stage, 1)}>
+                    <IoRefreshOutline />
+                </StyledRotateButton>
 
 			</StyledMobileControls>
 

--- a/src/components/MobileControls.jsx
+++ b/src/components/MobileControls.jsx
@@ -16,7 +16,7 @@ const MobileControls = ({ movePlayer, dropPlayer, setDropTime, level, playerRota
 				
                 {/* move down  */}
                 <div>
-					<StyledDirButton></StyledDirButton>
+					<StyledDirButton disabled></StyledDirButton>
 					<StyledDirButton onTouchStart={dropPlayer} onClick={() => setDropTime(1000 / (level + 1))}>
                         <IoArrowDownOutline />
                     </StyledDirButton>

--- a/src/components/Tetris.jsx
+++ b/src/components/Tetris.jsx
@@ -31,8 +31,8 @@ import FutureTetro from './FutureTetro';
 const Tetris = () => {
 	const [dropTime, setDropTime] = useState(null);
 	const [gameOver, setGameOver] = useState(false);
-	const [btnText, setBtnText] = useState('Start Game')
-	const [togglePause, setTogglePause] = useState(true)
+	const [btnText, setBtnText] = useState('Start Game');
+	const [togglePause, setTogglePause] = useState(true);
 	
 
 	// media queries
@@ -67,15 +67,19 @@ const Tetris = () => {
 	}
 
 	const pauseGame = () => {
-		if (player.tetromino.length > 1) {
-			setTogglePause(!togglePause)
-			if (togglePause === true) {
-				setDropTime(null)
-				console.log('Game paused')
-			} else {
-				setDropTime(1000 / (level + 1) + 200)
-				console.log('Game continues');
-			}
+		const isGameStarted = player.tetromino.length > 1;
+		
+		if (!isGameStarted || gameOver) {
+			return;
+		}
+
+		setTogglePause(!togglePause);
+		if (togglePause === true) {
+			setDropTime(null)
+			console.log('Game paused')
+		} else {
+			setDropTime(1000 / (level + 1) + 200)
+			console.log('Game continues');
 		}
 	}
 

--- a/src/components/styles/StyledMobileControls.js
+++ b/src/components/styles/StyledMobileControls.js
@@ -5,16 +5,12 @@ export const StyledControlWrapper = styled.section`
   display: flex;
   flex-direction: column;
   justify-items: flex-start;
-  margin: 1rem;
   padding: 0.5rem;
 `;
 
 export const StyledMobileControls = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: flex-start;
-  width: 98%;
-  margin: 0.5rem;
 
   div {
     display: flex;
@@ -43,13 +39,6 @@ export const StyledDirButton = styled.button`
   font-size: 0.9rem;
 `;
 
-export const StyledRotateCe = styled(StyledMobileControls)`
-  justify-content: flex-end;
-  align-self: flex-end;
-  align-items: flex-end;
-  width: 60%;
-`;
-
 export const StyledRotateButton = styled.button`
   box-sizing: border-box;
   height: 3.5rem;
@@ -63,6 +52,7 @@ export const StyledRotateButton = styled.button`
   outline: none;
   cursor: pointer;
   box-shadow: 0px 0px 2px 1px #999;
+  margin-left: auto;
 `;
 
 //   @media screen and (min-width: 600px) {

--- a/src/components/styles/StyledMobileControls.js
+++ b/src/components/styles/StyledMobileControls.js
@@ -20,6 +20,7 @@ export const StyledMobileControls = styled.div`
 `;
 
 export const StyleMCStartStop = styled(StyledMobileControls)`
+padding-top: 0.3rem;
   justify-content: center;
   align-items: center;
   div {

--- a/src/components/styles/StyledStageOverlay.js
+++ b/src/components/styles/StyledStageOverlay.js
@@ -4,9 +4,6 @@ const StyledStageOverlay = styled.section`
 	position: absolute;
 	width: 100%;
 	height: 100%;
-	height: -moz-available;
-	height: -webkit-fill-available;
-	height: fill-available;
 	background-color: rgba(0, 0, 0, 0.7);
 	text-align: center;
 	font-size: 2.9rem;

--- a/src/components/styles/StyledTetris.js
+++ b/src/components/styles/StyledTetris.js
@@ -19,7 +19,7 @@ export const StyledTetris = styled.div`
 
   aside {
 	width: 100%;
-    padding: 0 0 max(1rem, 3vmin) 0;
+    padding: 0 0 0.5rem 0;
     order: -1;
     display: flex;
 	justify-content: space-between;

--- a/src/components/styles/StyledTetris.js
+++ b/src/components/styles/StyledTetris.js
@@ -7,6 +7,7 @@ export const StyledTetrisWrapper = styled.div`
   background: url(${bgImage}) #000;
   background-size: cover;
   overflow: hidden;
+  outline: none;
 `;
 
 export const StyledTetris = styled.div`

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,9 @@
 body {
 	margin: 0;
-	overflow: hidden;
+	overscroll-behavior: none;
+	background-color: black;
 }
+
 body * {
 	font-family: Pixel, Arial, Helvetica, sans-serif;
 	-webkit-touch-callout: none;
@@ -20,12 +22,7 @@ body * {
 main {
 	display: flex;
 	flex-direction: column;
-	overflow: hidden;
 	min-height: 100vh;
+	overflow: hidden;
 }
 
-@media (min-width: 600px) {
-	main {
-		height: 100vh;
-	}
-}

--- a/src/index.css
+++ b/src/index.css
@@ -1,24 +1,30 @@
 body {
-  margin: 0;
+	margin: 0;
 }
 body * {
-  font-family: Pixel, Arial, Helvetica, sans-serif;
+	font-family: Pixel, Arial, Helvetica, sans-serif;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 
 @font-face {
-  font-family: "Pixel";
-  src: url("font/Pixel-LCD-7.woff") format("woff");
+	font-family: "Pixel";
+	src: url("font/Pixel-LCD-7.woff") format("woff");
 }
 
 main {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	min-height: 100vh;
 }
 
 @media (min-width: 600px) {
-  main {
-    height: 100vh;
-  }
+	main {
+		height: 100vh;
+	}
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 body {
 	margin: 0;
+	overflow: hidden;
 }
 body * {
 	font-family: Pixel, Arial, Helvetica, sans-serif;


### PR DESCRIPTION
Did the following:
- changed the height property of the stage overlay (was broken on mobile)
- disabled text select on all elements (was impossible to play on mobile otherwise)
- disabled pausing before the game started
- disabled vertical scroll on the body element (does not work on iOS devices)
- adjusted mobile controls: reduced extra padding, removed the div wrapper from the rotate button, disabled the non-functional button on move controls